### PR TITLE
Remove setting map contributor icon in filter component

### DIFF
--- a/src/app/components/filters/filters.component.ts
+++ b/src/app/components/filters/filters.component.ts
@@ -116,11 +116,6 @@ export class FiltersComponent implements OnInit {
   }
 
   public getAllContributorsIcons() {
-
-    this.contributorsIcons.set(
-      'mapbox',
-      this.configService.getValue('arlas.web.contributors').find(contrib => contrib.identifier === 'mapbox').icon
-    );
     this.arlasStartupService.contributorRegistry.forEach((v, k) => {
       if (v !== undefined) {
         this.contributorsIcons.set(


### PR DESCRIPTION
- the mapcontributor icon is now available in contributorRegistry of arlasStartupService
- Fix #216