### PR TITLE
Fix/init toolkit

### DIFF
--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.ts
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.ts
@@ -344,13 +344,13 @@ export class TimelineComponent implements OnInit {
 
   private resetHistogramsInputs(inputs: any) {
     Object.keys(inputs).forEach(key => {
-      if (key === 'chartType') {
+      if (key === 'chartType' && isNaN(inputs[key])) {
         inputs[key] = ChartType[inputs[key]];
-      } else if (key === 'dataType') {
+      } else if (key === 'dataType' && isNaN(inputs[key])) {
         inputs[key] = DataType[inputs[key]];
-      } else if (key === 'xAxisPosition') {
+      } else if (key === 'xAxisPosition' && isNaN(inputs[key])) {
         inputs[key] = Position[inputs[key]];
-      } else if (key === 'descriptionPosition') {
+      } else if (key === 'descriptionPosition' && isNaN(inputs[key])) {
         inputs = Position[inputs[key]];
       }
     });

--- a/projects/arlas-toolkit/src/lib/services/bookmark/bookmark.service.ts
+++ b/projects/arlas-toolkit/src/lib/services/bookmark/bookmark.service.ts
@@ -209,7 +209,7 @@ export class ArlasBookmarkService {
     if (language) {
       queryParams['lg'] = language;
     }
-    this.router.navigate(['.'], { queryParams: queryParams });
+    this.router.navigate(['.'], { queryParams: queryParams, relativeTo: this.activatedRoute});
   }
 
   private combineBookmarkFromIds(selectedBookmark: Set<string>, changeOperator = false): Set<string> {

--- a/projects/arlas-toolkit/src/lib/toolkit.component.ts
+++ b/projects/arlas-toolkit/src/lib/toolkit.component.ts
@@ -20,14 +20,13 @@
 import { AfterViewInit, Component, Input, OnInit } from '@angular/core';
 import { Location } from '@angular/common';
 import { ActivatedRoute, Params, Router } from '@angular/router';
-import { delay, of } from 'rxjs';
+import { interval } from 'rxjs';
 import {
   ArlasCollaborativesearchService, ArlasStartupService, ArlasConfigService
 } from './services/startup/startup.service';
 
 import { CONFIG_ID_QUERY_PARAM } from './tools/utils';
-import { TreeContributor } from 'arlas-web-contributors';
-import { Filter } from 'arlas-api';
+import { take } from 'rxjs/operators';
 @Component({
   selector: 'arlas-tool-root',
   templateUrl: './toolkit.component.html',
@@ -40,7 +39,6 @@ export class ToolkitComponent implements AfterViewInit, OnInit {
   public languages: string[];
   public analyticsOpen = false;
   public target: string;
-  @Input() public loadStrategy: 'url' | 'filter' = 'url';
 
   public constructor(private configService: ArlasConfigService,
     private arlasStartupService: ArlasStartupService,
@@ -110,7 +108,7 @@ export class ToolkitComponent implements AfterViewInit, OnInit {
     if (this.configService.getConfig() && this.configService.getConfig()['error'] !== undefined) {
       this.configService.confErrorBus.next(this.configService.getConfig()['error']);
     } else if (this.arlasStartupService.shouldRunApp) {
-      of(delay(400)).subscribe(() => {
+      interval(400).pipe(take(1)).subscribe(() => {
         const filter = this.activatedRoute.snapshot.queryParams['filter'];
         if (filter) {
           const dataModel = this.collaborativeService.dataModelBuilder(filter, true);

--- a/projects/arlas-toolkit/src/lib/toolkit.component.ts
+++ b/projects/arlas-toolkit/src/lib/toolkit.component.ts
@@ -78,7 +78,7 @@ export class ToolkitComponent implements AfterViewInit, OnInit {
         if (this.activatedRoute.snapshot.queryParams['ro']) {
           queryParams['ro'] = this.activatedRoute.snapshot.queryParams['ro'];
         }
-        this.router.navigate(['.'], { queryParams: queryParams });
+        this.router.navigate(['.'], { queryParams: queryParams, relativeTo: this.activatedRoute});
         if (collaborationEvent.id !== 'url') {
         }
       });


### PR DESCRIPTION
Currently, on init of toolkit component, we subscribe to `activatedRoute.queryParams` Observable, and if nothing is emitted we init without filter after 400ms

I realised that this subscribe is buggy in angular, and we don't need it. I kept the 400ms delay as before to not include a regression.

@mbarbet @sebbousquet we'll discuss it together tomorrow 