### PR TITLE
Set correct groups for preview when sharing a config

### DIFF
--- a/projects/arlas-toolkit/src/lib/components/config-manager/share-config/share-config.component.ts
+++ b/projects/arlas-toolkit/src/lib/components/config-manager/share-config/share-config.component.ts
@@ -80,7 +80,15 @@ export class ShareConfigComponent implements OnInit {
         next: () => this.updateEmitter.emit([true, {}]),
         error: (err) => this.updateEmitter.emit([false, err])
       });
-    this.persistenceService.updatePreview(this.config.name.concat('_preview'), this.config.readers, this.config.writers);
+    let previewReaders = [];
+    let previewWriters = [];
+    if (this.config.readers) {
+      previewReaders = this.config.readers.map(reader => reader.replace('config.json', 'preview'));
+    }
+    if (this.config.writers) {
+      previewWriters = this.config.writers.map(writer => writer.replace('config.json', 'preview'));
+    }
+    this.persistenceService.updatePreview(this.config.name.concat('_preview'), previewReaders, previewWriters);
   }
 
   public close() {


### PR DESCRIPTION
- Fix #573 