### PR TITLE
fix: add condition in contributors filter

### DIFF
--- a/projects/arlas-toolkit/src/lib/services/configuration-updater/configurationUpdater.service.ts
+++ b/projects/arlas-toolkit/src/lib/services/configuration-updater/configurationUpdater.service.ts
@@ -53,7 +53,7 @@ export class ArlasConfigurationUpdaterService {
           });
         }
         /** Compute contributors have metrics */
-        if (contributor.metrics && contributor.metrics.find(m => !availableFields.has(m.field))) {
+        if (contributor.metrics && contributor.metrics.find(m => !availableFields.has(m.field) && m.metric !== 'count')) {
           contributorsToRemove.add(contributor.identifier);
         }
         /** swimlanes contributors have a specific structure for `aggregationmodels`  */


### PR DESCRIPTION
When filtering contributors to display, add a condition to avoid deleting metric count contributors

Fix #580