### PR TITLE
fix: upgrade peerDependency

### DIFF
--- a/projects/arlas-toolkit/package.json
+++ b/projects/arlas-toolkit/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "~13.0.0",
     "@angular/platform-browser-dynamic": "~13.0.0",
     "@angular/router": "~13.0.0",
-    "@biesbjerg/ngx-translate-extract": "7.0.4",
+    "@gisaia/ngx-translate-extract": "^8.1.0",
     "@biesbjerg/ngx-translate-extract-marker": "1.0.0",
     "@ngx-translate/core": "^14.0.0",
     "@ngx-translate/http-loader": "^7.0.0",


### PR DESCRIPTION
Upgrade peerDependency for ngx-translate-extract to avoid import of old version