### PR TITLE
Fix: remove code from config updater

### DIFF
--- a/projects/arlas-toolkit/src/lib/components/tag/tag.component.spec.ts
+++ b/projects/arlas-toolkit/src/lib/components/tag/tag.component.spec.ts
@@ -14,7 +14,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ArlasConfigurationUpdaterService } from '../../services/configuration-updater/configurationUpdater.service';
 import {
   ArlasCollaborativesearchService,
-  ArlasConfigService, ArlasStartupService, FETCH_OPTIONS
+  ArlasConfigService, ArlasStartupService, CONFIG_UPDATER, FETCH_OPTIONS
 } from '../../services/startup/startup.service';
 import { ArlasTagService } from '../../services/tag/tag.service';
 import { TagComponent } from './tag.component';
@@ -45,6 +45,7 @@ describe('TagComponent', () => {
           useClass: ArlasConfigurationUpdaterService
         },
         { provide: FETCH_OPTIONS, useValue: {} },
+        { provide: CONFIG_UPDATER, useValue: {} },
         {
           provide: GET_OPTIONS,
           useFactory: getOptionsFactory,

--- a/projects/arlas-toolkit/src/lib/toolkit.module.ts
+++ b/projects/arlas-toolkit/src/lib/toolkit.module.ts
@@ -95,30 +95,6 @@ export function getOptionsFactory(arlasAuthService: AuthentificationService): an
   return getOptions;
 }
 
-export function configUpdater(data) {
-  /** FIX wrong v15 map filters about Infinity values */
-  if (!!data[0] && !!data[0].arlas && !!data[0].arlas.web && !!data[0].arlas.web.components.mapgl) {
-    const layers = data[0].arlas.web.components.mapgl.input.mapLayers.layers;
-    layers.forEach(layer => {
-      if (!!layer.filter && Array.isArray(layer.filter)) {
-        const filters = [];
-        layer.filter.forEach(expression => {
-          if (Array.isArray(expression) && expression.length === 3) {
-            if (expression[0] === '!=' && expression[2] === 'Infinity') {
-              expression = ['<=', (expression[1] as any).replace(/\./g, '_'), Number.MAX_VALUE];
-            } else if (expression[0] === '!=' && expression[2] === '-Infinity') {
-              expression = ['>=', (expression[1] as any).replace(/\./g, '_'), -Number.MAX_VALUE];
-            }
-          }
-          filters.push(expression);
-        });
-        layer.filter = filters;
-      }
-    });
-  }
-  return data[0];
-}
-
 export const MY_CUSTOM_FORMATS = {
   parseInput: 'lll',
   fullPickerInput: 'll LTS',
@@ -149,7 +125,7 @@ export const MY_CUSTOM_FORMATS = {
     },
     {
       provide: CONFIG_UPDATER,
-      useValue: configUpdater
+      useFactory: configUpdaterFactory
     },
     { provide: MAT_DIALOG_DATA, useValue: {} },
     { provide: MatDialogRef, useValue: {} },

--- a/projects/arlas-toolkit/src/public-api.ts
+++ b/projects/arlas-toolkit/src/public-api.ts
@@ -102,7 +102,7 @@ export { ArlasTaggerModule } from './lib/tagger.module';
 export { ToolkitRoutingModule } from './lib/toolkit-routing.module';
 export { ToolkitComponent } from './lib/toolkit.component';
 export {
-  ArlasToolKitModule, auhtentServiceFactory, configServiceFactory, configUpdater, configUpdaterFactory,
+  ArlasToolKitModule, auhtentServiceFactory, configServiceFactory, configUpdaterFactory,
   getOptionsFactory, localDatePickerFactory, MY_CUSTOM_FORMATS, settingsServiceFactory, startupServiceFactory
 } from './lib/toolkit.module';
 export { ArlasDataSource } from './lib/tools/arlasDataSource';


### PR DESCRIPTION
The CONFIG_UPDATER  must be provided in the final ARLAS-wui app, so we don't have to put any intelligence into it in the toolbox.