### PR TITLE
fix: timeline shortcut

### DIFF
--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.css
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.css
@@ -1,4 +1,30 @@
 .arlas-time-shortcuts--container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  position: absolute;
+  bottom: 125px;
+  left: 7px;
+  z-index: 1000;
+  background-color: transparent;
+  padding: 0 0 5px 5px;
+  overflow: visible;
+}
+
+.arlas-time--tools {
+  display: flex;
+  align-items: center;
+}
+
+.arlas-timeline-toggle {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  background-color: white;
+  width: 24px;
+  height: 24px;
+  margin-left: 4px;
+  cursor: pointer;
 }
 
 .shortcut-button {
@@ -6,6 +32,7 @@
   float: right;
   display: flex;
   height: 30px;
+  width: fit-content;
   justify-content: center;
   align-items: center;
   border-top-left-radius: 2px;
@@ -69,7 +96,8 @@
 .arlas-time-shortcuts__list {
   list-style-type: none;
   margin-bottom: 0;
-  padding-right: 20px;
+  /* Align in width the time shortcuts and the time picker */
+  padding-right: 13px;
   padding-left: 0;
 }
 

--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.html
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.html
@@ -4,15 +4,15 @@
       <li class="arlas-time-shortcut" *ngFor="let shortCut of timeShortcutsMap.get(shortcutType)" (click)="setShortcut(shortCut)">{{shortCut.label | translate}}</li>
     </ul>
   </div>
-  <div>
+  <div class="arlas-time--tools">
     <mat-basic-chip class="shortcut-button">
       <mat-icon id="shortcut-btn" class="shortcut-button__icon" [class.cursor]="timeShortcuts?.length > 0" (click)="showSortcuts()" matTooltip="{{HIDE_SHOW + ' time shortcuts' | translate}}"
         [matTooltipPosition]="'above'">access_time</mat-icon>
       <div *ngIf="activeDatePicker" class="arlas-datepicker-container">
         <arlas-tool-date-picker class="shortcut-button__label"
-        [startSelectedDate]="timelineContributor?.intervalSelection?.startvalue"
-        [endSelectedDate]="timelineContributor?.intervalSelection?.endvalue"
-        [timelineComponent]="timelineComponent">
+          [startSelectedDate]="timelineContributor?.intervalSelection?.startvalue"
+          [endSelectedDate]="timelineContributor?.intervalSelection?.endvalue"
+          [timelineComponent]="timelineComponent">
         </arlas-tool-date-picker>
         <div class="time-zone" matTooltip="{{'Time zone' | translate}} {{timeZone}}" [matTooltipPosition]="'above'">
           <mat-icon class="time-zone-icon" >language</mat-icon>
@@ -29,7 +29,10 @@
       <div *ngIf="showRemoveIcon" class="shortcut-remove-filter" matTooltip="{{'Remove time filter' | translate}}" [matTooltipPosition]="'before'" (click)="removeTimelineCollaboration()">
         <mat-icon class="shortcut-remove-filter-icon" >clear</mat-icon>
       </div>
-
     </mat-basic-chip>
+    <div class="arlas-timeline-toggle" (click)="toggleTimeline()">
+      <mat-icon *ngIf="!isDisplayHistogram">keyboard_arrow_up</mat-icon>
+      <mat-icon *ngIf="isDisplayHistogram">keyboard_arrow_down</mat-icon>
+    </div>
   </div>
 </div>

--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.ts
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline-shortcut/timeline-shortcut.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, EventEmitter, Output } from '@angular/core';
 import { HistogramContributor } from 'arlas-web-contributors';
 import { StringifiedTimeShortcut, SelectedOutputValues } from 'arlas-web-contributors/models/models';
 import { ArlasCollaborativesearchService, ArlasStartupService } from '../../../services/startup/startup.service';
@@ -36,6 +36,18 @@ export class TimelineShortcutComponent implements OnInit {
    * @description Whether the date picker is enabled
    */
   @Input() public activeDatePicker = false;
+
+  /**
+   * @Input : Angular
+   * @description Whether to display the timelines' histogram
+   */
+  @Input() public isDisplayHistogram = true;
+
+  /**
+   * @Output : Angular
+   * @description Emits when the value of isDisplayHistogram changes
+   */
+  @Output() public isDisplayHistogramChange: EventEmitter<boolean> = new EventEmitter();
 
   public timelineContributor: HistogramContributor;
   public timeShortcuts: Array<StringifiedTimeShortcut>;
@@ -118,6 +130,11 @@ export class TimelineShortcutComponent implements OnInit {
    */
   public getKeys(map): Array<string> {
     return Array.from(map.keys());
+  }
+
+  public toggleTimeline() {
+    this.isDisplayHistogram = !this.isDisplayHistogram;
+    this.isDisplayHistogramChange.next(this.isDisplayHistogram);
   }
 
   /**

--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.css
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.css
@@ -30,35 +30,12 @@
   cursor: pointer;
 }
 
-.arlas-timeline--tools {
-  display: flex;
-  align-items: center;
-  position: absolute;
-  bottom: 125px;
-  overflow: visible;
-  right: 7px;
-  z-index: 1000;
-  background-color: transparent;
-  padding: 0 0 5px 5px;
-}
-
 .show-detailedtimeline-true {
   visibility: visible;
 }
 .show-detailedtimeline-false {
   visibility: hidden;
   height: 0;
-}
-
-.arlas-timeline-toggle {
-  display: flex;
-  justify-content: center;
-  flex-direction: column;
-  background-color: white;
-  width: 24px;
-  height: 24px;
-  margin-left: 4px;
-  cursor: pointer;
 }
 
 .arlas-timeline-hidden {

--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.html
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.html
@@ -1,11 +1,6 @@
-<div class="arlas-timeline--tools">
-  <arlas-timeline-shortcut class="arlas-timeline--timeshortcuts" [activeDatePicker]="activeDatePicker"
-    [timelineComponent]="timelineComponent" [dateFormat]="timelineComponent?.dateFormat"></arlas-timeline-shortcut>
-  <div class="arlas-timeline-toggle" (click)="toggleTimeline()">
-    <mat-icon *ngIf="!isDisplayHistogram">keyboard_arrow_up</mat-icon>
-    <mat-icon *ngIf="isDisplayHistogram">keyboard_arrow_down</mat-icon>
-  </div>
-</div>
+<arlas-timeline-shortcut class="arlas-timeline--timeshortcuts" [activeDatePicker]="activeDatePicker"
+    [timelineComponent]="timelineComponent" [dateFormat]="timelineComponent?.dateFormat"
+    [isDisplayHistogram]="isDisplayHistogram" (isDisplayHistogramChange)="toggleTimeline()"></arlas-timeline-shortcut>
 
 <div class="arlas-timeline--container" *ngIf="isDisplayHistogram" #arlasTimeline>
   <div class="arlas-timeline--legend" *ngIf="!!timelineLegend && timelineLegend.length > 1">


### PR DESCRIPTION
Align shortcut elements when shortcuts are open

![image](https://github.com/gisaia/ARLAS-wui-toolkit/assets/104018401/5c8442e2-1d30-41ec-82b8-b386d4d6753c)
