### PR TITLE
fix: align to the top all widgets except donuts

### DIFF
--- a/projects/arlas-toolkit/src/lib/components/analytics/analytics-board/analytics-board.component.html
+++ b/projects/arlas-toolkit/src/lib/components/analytics/analytics-board/analytics-board.component.html
@@ -20,7 +20,7 @@
       </mat-expansion-panel-header>
       <div class="analytics-board-group analytics-group-{{group.components.length}}">
         <div *ngFor="let component of group.components;let i = index" class="analytics-board-card"
-          [ngClass]="component?.customizedCssClass">
+          [ngClass]="component?.customizedCssClass" [class.centered]="component?.componentType === 'donut'">
           <arlas-tool-widget
             id="{{component?.componentType + '-' +  component?.contributorId + '-' + group.groupId + '-' + i}}"
             [componentType]="component?.componentType" [contributorId]="component?.contributorId"

--- a/projects/arlas-toolkit/src/lib/components/analytics/analytics-board/analytics-board.component.scss
+++ b/projects/arlas-toolkit/src/lib/components/analytics/analytics-board/analytics-board.component.scss
@@ -30,13 +30,17 @@
     display: flex;
     flex-direction: row;
     padding-top: 3px;
-    align-items: center; /** to center vertically powerbars and donuts*/
+    align-items: flex-start;
 
     .analytics-board-card{
       flex:1;
       width: 100%;
       margin: 3px;
       padding: 3px;
+
+      &.centered {
+        align-self: center;
+      }
 
       .mat-card-title{
         font-size: 15px;

--- a/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.ts
+++ b/projects/arlas-toolkit/src/lib/components/timeline/timeline/timeline.component.ts
@@ -221,7 +221,7 @@ export class TimelineComponent implements OnInit {
   }
 
   public emitTooltip(tooltip: HistogramTooltip, e: ElementRef) {
-    const yOffset = -140;
+    const yOffset = this.timelineLegend && this.timelineLegend.length > 1 ? -140 : -110;
     let xOffset = tooltip.xPosition;
     let right = false;
     if (!!tooltip && tooltip.shown && tooltip.xPosition > tooltip.chartWidth / 2) {


### PR DESCRIPTION
Fix gisaia/ARLAS-wui#684
![image](https://github.com/gisaia/ARLAS-wui-toolkit/assets/104018401/31ef77fa-9aec-404d-866f-649024cb7968)
![image](https://github.com/gisaia/ARLAS-wui-toolkit/assets/104018401/22af561f-e0fe-4c25-a147-7186146116ba)
