### PR TITLE
fix: properly reset tour

### DIFF
--- a/projects/arlas-toolkit/src/lib/services/walkthrough/walkthrough.service.ts
+++ b/projects/arlas-toolkit/src/lib/services/walkthrough/walkthrough.service.ts
@@ -206,5 +206,7 @@ export class ArlasWalkthroughService {
    */
   public resetTour() {
     localStorage.removeItem(this.tourData.id);
+    // Hopscotch stores the tour step in the session storage
+    this.endTour(true);
   }
 }


### PR DESCRIPTION
When resetting a tour, the step stored by hopscotch in the session storage needs to be reset. 