### PR TITLE
feat: export error classes for external use

### DIFF
--- a/projects/arlas-toolkit/assets/i18n/en.json
+++ b/projects/arlas-toolkit/assets/i18n/en.json
@@ -242,7 +242,7 @@
 	"dashboard access forbidden": "You are not authorised to access this dashboard.",
 	"access not authorized": "Log in to access this page.",
 	"acces forbidden": "You are not authorised to access this page.",
-	"ARLAS ecountered an error": "ARLAS ecountered an error",
+	"ARLAS encountered an error": "ARLAS encountered an error",
 	"dashboard does not exist": "This dashboard was not found.",
 	"go to arlas hub": "Go to ARLAS-Hub.",
 	"The connection to ARLAS backend services is lost": "The connection to ARLAS backend services is lost.",

--- a/projects/arlas-toolkit/assets/i18n/fr.json
+++ b/projects/arlas-toolkit/assets/i18n/fr.json
@@ -253,7 +253,7 @@
 	"yes": "oui",
 	"access not authorized": "Veuillez vous connecter pour accéder à cette page.",
 	"acces forbidden": "Vous n'êtes pas autorisé(e) à accéder à cette page.",
-	"ARLAS ecountered an error": "ARLAS a rencontré une erreur",
+	"ARLAS encountered an error": "ARLAS a rencontré une erreur",
 	"The connection to ARLAS backend services is lost": "La connexion aux backends ARLAS a échoué.",
 	"The connection to ARLAS-server is lost": "La connexion à ARLAS-server a échoué.",
 	"The connection to ARLAS-persistence is lost": "La connexion à ARLAS-persistence a échoué.",

--- a/projects/arlas-toolkit/src/lib/services/authentification/authentification.service.ts
+++ b/projects/arlas-toolkit/src/lib/services/authentification/authentification.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { AuthConfig, OAuthErrorEvent, OAuthService, OAuthStorage, UserInfo } from 'angular-oauth2-oidc';
+import { AuthConfig, OAuthErrorEvent, OAuthEvent, OAuthService, OAuthStorage, UserInfo } from 'angular-oauth2-oidc';
 import { BehaviorSubject, Observable, ReplaySubject, combineLatest } from 'rxjs';
 import { from } from 'rxjs/internal/observable/from';
 import { filter } from 'rxjs/internal/operators/filter';
@@ -21,7 +21,7 @@ export class AuthentificationService extends ArlasAuthentificationService {
   private isDoneLoadingSubject = new ReplaySubject<boolean>();
   public isDoneLoading = this.isDoneLoadingSubject.asObservable();
 
-  public silentRefreshErrorSubject;
+  public silentRefreshErrorSubject: Observable<OAuthEvent>;
   /**
    * Publishes `true` if and only if (a) all the asynchronous initial
    * login calls have completed or errorred, and (b) the user ended up

--- a/projects/arlas-toolkit/src/lib/tools/errors/backend-error.ts
+++ b/projects/arlas-toolkit/src/lib/tools/errors/backend-error.ts
@@ -29,7 +29,7 @@ export class BackendError extends ArlasError {
       this.service = service;
     }
     this.hubUrl = hubUrl;
-    this.title = 'ARLAS ecountered an error';
+    this.title = 'ARLAS encountered an error';
     if (this.status === 404) {
       this.showAction = true;
       this.actionMessage = 'go to arlas hub';

--- a/projects/arlas-toolkit/src/public-api.ts
+++ b/projects/arlas-toolkit/src/public-api.ts
@@ -138,3 +138,7 @@ export { ArlasIamApi } from './lib/services/startup/startup.service';
 export { ArlasAuthentificationService } from './lib/services/arlas-authentification/arlas-authentification.service';
 export { ProcessComponent } from './lib/components/process/process.component';
 export { ProcessService } from './lib/services/process/process.service';
+export { ArlasError, ActionType } from './lib/tools/errors/error';
+export { AuthorisationError } from './lib/tools/errors/authorisation-error';
+export { BackendError } from './lib/tools/errors/backend-error';
+export { DashboardError } from './lib/tools/errors/dashboard-error';


### PR DESCRIPTION
- fix typo
- export error classes to allow to declare custom errors as well as use errorService functionalities