### PR TITLE
fix: correct return types of CollectionService

### DIFF
--- a/projects/arlas-toolkit/src/lib/services/collection/arlas-collection.service.ts
+++ b/projects/arlas-toolkit/src/lib/services/collection/arlas-collection.service.ts
@@ -61,18 +61,18 @@ export class ArlasCollectionService extends BaseCollectionService {
     }
   }
 
-  public getUnit(collectionName: string): string | null {
+  public getUnit(collectionName: string): string {
     if (this.appUnits.has(collectionName)) {
       return this.appUnits.get(collectionName).unit;
     }
-    return null;
+    return collectionName;
   };
 
   public getAllUnits(): CollectionUnit[] {
     return [...this.appUnits.values()];
   };
 
-  public getDisplayName(collectionName: string): string | undefined {
+  public getDisplayName(collectionName: string): string {
     return this.displayName.get(collectionName) || collectionName;
   }
 }


### PR DESCRIPTION
Change return types of CollectionService methods to match the ones of the abstract class and avoid compilation errors when importing the toolkit